### PR TITLE
Resolve Test function logic #3 bug.

### DIFF
--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
@@ -70,6 +70,9 @@ function Set-TargetResource
         if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
         {
             $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
+        elseif ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $Name))
+        {
+            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
         }else{
             $CertificatePath = Join-path $CertificateBaseLocation $Name
         }

--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
@@ -72,7 +72,7 @@ function Set-TargetResource
             $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
         elseif ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $Name))
         {
-            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
+            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $Name).PSPath
         }else{
             $CertificatePath = Join-path $CertificateBaseLocation $Name
         }

--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
@@ -2,25 +2,18 @@ function Get-TargetResource
 {
     [OutputType([Hashtable])]
     param (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Name,
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Path,
-        [parameter()]
-        [ValidateSet('LocalMachine','CurrentUser')]
-        [string]
-        $Location = 'LocalMachine',
-        [parameter()]        
-        [string]
-        $Store = 'My',
-        [parameter()]
-        [ValidateSet('Present','Absent')]
-        [string]
-        $Ensure = 'Present'
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Name,
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+    [ValidateSet('LocalMachine','CurrentUser')]
+    [string]$Location = 'LocalMachine',
+    [string]$Store = 'My',
+    [ValidateSet('Present','Absent')]
+    [string]$Ensure = 'Present',
+    [string]$Password
     )
     
     #Needs to return a hashtable that returns the current
@@ -50,43 +43,38 @@ function Get-TargetResource
 function Set-TargetResource
 {
     param (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Name,
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Path,
-        [parameter()]
-        [ValidateSet('LocalMachine','CurrentUser')]
-        [string]
-        $Location = 'LocalMachine',
-        [parameter()]        
-        [string]
-        $Store = 'My',
-        [parameter()]
-        [ValidateSet('Present','Absent')]
-        [string]
-        $Ensure = 'Present',
-        [parameter()]        
-        [string]
-        $Password
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Name,
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+    [ValidateSet('LocalMachine','CurrentUser')]
+    [string]$Location = 'LocalMachine',
+    [string]$Store = 'My',
+    [ValidateSet('Present','Absent')]
+    [string]$Ensure = 'Present',
+    [string]$Password
     )
 
     $CertificateBaseLocation = "cert:\$Location\$Store"
     
     if ($Ensure -like 'Present')
     {        
-	$SecurePassword = ConvertTo-SecureString -string $Password -AsPlainText -Force
+        $SecurePassword = ConvertTo-SecureString -string $Password -AsPlainText -Force
         Write-Verbose "Adding $path to $CertificateBaseLocation."
         Import-PfxCertificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path -Password $SecurePassword
     }
     else
     {
-        $CertificateLocation = Join-path $CertificateBaseLocation $Name
-        Write-Verbose "Removing $CertificateLocation."
-        dir $CertificateLocation | Remove-Item -Force -Confirm:$false   
+        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
+        {
+            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
+        }else{
+            $CertificatePath = Join-path $CertificateBaseLocation $Name
+        }
+        Write-Verbose "Removing Certificate $Name."
+        dir $CertificatePath | Remove-Item -Force -Confirm:$false
     }
 }
 
@@ -94,57 +82,69 @@ function Test-TargetResource
 {
     [OutputType([boolean])]
     param (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Name,
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Path,
-        [parameter()]
-        [ValidateSet('LocalMachine','CurrentUser')]
-        [string]
-        $Location = 'LocalMachine',
-        [parameter()]        
-        [string]
-        $Store = 'My',
-        [parameter()]
-        [ValidateSet('Present','Absent')]
-        [string]
-        $Ensure = 'Present',
-	[parameter()]        
-        [string]
-        $Password
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Name,
+    [parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+    [ValidateSet('LocalMachine','CurrentUser')]
+    [string]$Location = 'LocalMachine',
+    [string]$Store = 'My',
+    [ValidateSet('Present','Absent')]
+    [string]$Ensure = 'Present',
+    [string]$Password
     )
 
     $IsValid = $false
-
-    $CertificateLocation = "cert:\$Location\$Store\$Name"
-
-    if ($Ensure -like 'Present')
+    $CertificateBaseLocation = "cert:\$Location\$Store"
+    if(Test-Path $Path)
     {
-        Write-Verbose "Checking for $Name to be present in the $location store under $store."
-        if (Test-Path $CertificateLocation)
+        Write-Verbose "Filepath test is good. Grabbing PFX thumbprint."
+        $securepass = ConvertTo-SecureString -String $Password -Force –AsPlainText
+        $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+        $certificate.Import($Path, $securepass, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet)
+        $thumbprint = $certificate.thumbprint
+        $pathGood = $true
+    }else{
+        
+    }
+    
+    if (($Ensure -eq 'Present') -and ($pathGood))
+    {
+        Write-Verbose "Checking for $thumbprint thumbprint in the $location store under $store."
+        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
         {
-            Write-Verbose "Found a matching certficate at $CertificateLocation"
+            Write-Verbose "Found a matching certificate in Certificate Store $store"
             $IsValid = $true
+        }else{
+            Write-Verbose "Unable to find a matching certficate in Certificate Store $store"
         }
-        else
+    }
+    elseif ($Ensure -eq "Present")
+    {
+        Write-Verbose "Ensure is Present, but the filepath test is bad. Unable to grab PFX thumbprint."
+        Return $false
+    }
+    elseif (($Ensure -eq 'Absent') -and ($pathGood))
+    {
+        Write-Verbose "Checking for $thumbprint to be absent in the $location store under $store."
+        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
         {
-            Write-Verbose "Unable to find a matching certficate at $CertificateLocation"
+            Write-Verbose "Found the matching certificate in Certificate Store $store"
+        }else{
+            Write-Verbose "Unable to find a matching certificate in Certificate Store $store"
+            $IsValid = $true
         }
     }
     else
     {
-        Write-Verbose "Checking for $Name to be absent in the $location store under $store."
-        if (Test-Path $CertificateLocation)
+        Write-Verbose "Certificate Thumbprint not available./nChecking $Name for Name or Thumbprint match to be present in the $location store under $store."
+        if ([bool](Get-ChildItem $CertificateBaseLocation | ? {@($_.name,$_.thumbprint) -like $Name}))
         {
-            Write-Verbose "Found a matching certficate at $CertificateLocation"            
-        }
-        else
-        {
-            Write-Verbose "Unable to find a matching certficate at $CertificateLocation"
+            Write-Verbose "Found a matching certificate at $CertificateLocation"
+        }else{
+            Write-Verbose "Unable to find a matching certificate at $CertificateLocation"
             $IsValid = $true
         }
     }


### PR DESCRIPTION
This request solves the bug of removing the an incorrect certificate if two certs are present with the same name (should not occur).
That said, there is a fallback solution in-case you are removing the certificate by name only. This is not recommended and is a last-case scenario. Name value for Absent can be Name or Thumbprint for removal Note: removing the certificate by path requires the PFX to be retained in the path variable. Setting Name to Thumbprint allows removal of specific cert without conflict for a new certificate at the original path.(Do not specify a valid path in the Absent cert in this case.)