### PR TITLE
Numerous updates

### DIFF
--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
@@ -10,10 +10,11 @@ function Get-TargetResource
     [string]$Path,
     [ValidateSet('LocalMachine','CurrentUser')]
     [string]$Location = 'LocalMachine',
-    [string]$Store = 'My',
+    [string[]]$Store = 'My',
     [ValidateSet('Present','Absent')]
     [string]$Ensure = 'Present',
-    [string]$Password
+    [string]$Password,
+    [pscredential]$SecurePassword
     )
     
     #Needs to return a hashtable that returns the current
@@ -51,34 +52,44 @@ function Set-TargetResource
     [string]$Path,
     [ValidateSet('LocalMachine','CurrentUser')]
     [string]$Location = 'LocalMachine',
-    [string]$Store = 'My',
+    [string[]]$Store = 'My',
     [ValidateSet('Present','Absent')]
     [string]$Ensure = 'Present',
-    [string]$Password
+    [string]$Password,
+    [pscredential]$SecurePassword
     )
 
-    $CertificateBaseLocation = "cert:\$Location\$Store"
-    
-    if ($Ensure -like 'Present')
-    {        
-        $SecurePassword = ConvertTo-SecureString -string $Password -AsPlainText -Force
-        Write-Verbose "Adding $path to $CertificateBaseLocation."
-        Import-PfxCertificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path -Password $SecurePassword
-    }
-    else
+    if($PSBoundparameters.Password)
     {
-        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
-        {
-            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint).PSPath
-        elseif ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $Name))
-        {
-            $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $Name).PSPath
-        }else{
-            $CertificatePath = Join-path $CertificateBaseLocation $Name
-        }
-        Write-Verbose "Removing Certificate $Name."
-        dir $CertificatePath | Remove-Item -Force -Confirm:$false
+        $SecurePassword = ConvertTo-SecureString -string $Password -AsPlainText -Force
     }
+    if(-not $SecurePassword)
+    {$noenc = $true}
+    foreach ($Store in $($PSBoundparameters.Store))
+    {
+        $CertificateBaseLocation = "cert:\$Location\$Store"
+        if ($Ensure -like 'Present')
+        {
+            Write-Verbose "Importing $path to $CertificateBaseLocation."
+            if($noenc){Import-Certificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path
+            }else{
+            Import-PfxCertificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path -Password $SecurePassword
+            }
+        }
+        else
+        {
+            if ([bool](Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $thumbprint))
+            {
+                $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $thumbprint).PSPath
+            }elseif ([bool](Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $Name))
+            {
+                $CertificatePath = (Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $Name).PSPath
+            }else{
+                $CertificatePath = Join-path $CertificateBaseLocation $Name
+            }
+            Write-Verbose "Removing Certificate $Name."
+            dir $CertificatePath | Remove-Item -Force -Confirm:$false
+        }
 }
 
 function Test-TargetResource
@@ -93,67 +104,96 @@ function Test-TargetResource
     [string]$Path,
     [ValidateSet('LocalMachine','CurrentUser')]
     [string]$Location = 'LocalMachine',
-    [string]$Store = 'My',
+    [string[]]$Store = 'My',
     [ValidateSet('Present','Absent')]
     [string]$Ensure = 'Present',
-    [string]$Password
+    [string]$Password,
+    [pscredential]$SecurePassword
     )
 
     $IsValid = $false
-    $CertificateBaseLocation = "cert:\$Location\$Store"
+    $falsecount = 0
+    if($PSBoundparameters.Password)
+    {
+        $SecurePassword = ConvertTo-SecureString -string $Password -AsPlainText -Force
+    }
     if(Test-Path $Path)
     {
         Write-Verbose "Filepath test is good. Grabbing PFX thumbprint."
-        $securepass = ConvertTo-SecureString -String $Password -Force –AsPlainText
-        $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-        $certificate.Import($Path, $securepass, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet)
-        $thumbprint = $certificate.thumbprint
+        
+        if(-not $SecurePassword){
+            $thumbprint = Get-Thumbprint -Path $Path
+        }else{
+            $thumbprint = Get-Thumbprint -Path $Path -SecurePassword $SecurePassword
+        }
         $pathGood = $true
     }else{
+        $pathGood = $false
+    }
+    foreach ($Store in $($PSBoundparameters.Store))
+    {
+        $CertificateBaseLocation = "cert:\$Location\$Store"
         
-    }
-    
-    if (($Ensure -eq 'Present') -and ($pathGood))
-    {
-        Write-Verbose "Checking for $thumbprint thumbprint in the $location store under $store."
-        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
+        
+        if (($Ensure -eq 'Present') -and ($pathGood))
         {
-            Write-Verbose "Found a matching certificate in Certificate Store $store"
-            $IsValid = $true
-        }else{
-            Write-Verbose "Unable to find a matching certficate in Certificate Store $store"
+            Write-Verbose "Checking for thumbprint $thumbprint in the $location store under $store."
+            if ([bool](Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $thumbprint))
+            {
+                Write-Verbose "Found a matching certificate in Certificate Store $store"
+                $IsValid = $true
+            }else{
+                Write-Verbose "Unable to find a matching certificate in Certificate Store $store"
+                $falsecount ++
+            }
+        }
+        elseif ($Ensure -eq "Present")
+        {
+            Write-Verbose "Ensure is Present, but the filepath test is bad. Unable to grab Certificate thumbprint./nUsing $Name."
+            if ([bool](Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $Name){$IsValid = $true}
+            else{$falsecount ++}
+        }
+        elseif (($Ensure -eq 'Absent') -and ($pathGood))
+        {
+            Write-Verbose "Checking for $thumbprint to be absent in the $location store under $store."
+            if ([bool](Get-childitem -Path $CertificateBaseLocation | Where-object thumbprint -eq $thumbprint))
+            {
+                Write-Verbose "Found the matching certificate in Certificate Store $store"
+                $falsecount ++
+            }else{
+                Write-Verbose "Unable to find a matching certificate in Certificate Store $store"
+                $IsValid = $true
+            }
+        }
+        else
+        {
+            Write-Verbose "Certificate Thumbprint not available./nChecking for Thumbprint match against $name in Certificate Store $store."
+            if ([bool](Get-ChildItem $CertificateBaseLocation | Where-object thumbprint -eq $Name))
+            {
+                Write-Verbose "Found a matching certificate in Certificate Store $store"
+                $falsecount ++
+            }else{
+                Write-Verbose "Unable to find a matching certificate in Certificate Store $store"
+                $IsValid = $true
+            }
         }
     }
-    elseif ($Ensure -eq "Present")
-    {
-        Write-Verbose "Ensure is Present, but the filepath test is bad. Unable to grab PFX thumbprint."
-        Return $false
-    }
-    elseif (($Ensure -eq 'Absent') -and ($pathGood))
-    {
-        Write-Verbose "Checking for $thumbprint to be absent in the $location store under $store."
-        if ([bool](Get-childitem -Path $CertificateBaseLocation | ? thumbprint -eq $thumbprint))
-        {
-            Write-Verbose "Found the matching certificate in Certificate Store $store"
-        }else{
-            Write-Verbose "Unable to find a matching certificate in Certificate Store $store"
-            $IsValid = $true
-        }
-    }
-    else
-    {
-        Write-Verbose "Certificate Thumbprint not available./nChecking $Name for Name or Thumbprint match to be present in the $location store under $store."
-        if ([bool](Get-ChildItem $CertificateBaseLocation | ? {@($_.name,$_.thumbprint) -like $Name}))
-        {
-            Write-Verbose "Found a matching certificate at $CertificateLocation"
-        }else{
-            Write-Verbose "Unable to find a matching certificate at $CertificateLocation"
-            $IsValid = $true
-        }
-    }
-
     #Needs to return a boolean  
-    return $IsValid
+    if(($falsecount -eq 0) -and $IsValid = $true){ Return $true }
+    else{ return $false }
 }
 
+function Get-Thumbprint
+{
+    param (
+    [parameter(Mandatory = $true)]
+    [string]$Path,
+    [pscredential]$SecurePassword
+    )
+    if(-not $PSboundparameters.SecurePassword){$SecurePassword = $null}
+    $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+    $certificate.Import($Path, $SecurePassword, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet)
+    Return $certificate.thumbprint
+}
 
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.psm1
@@ -202,7 +202,7 @@ function Get-Thumbprint
     [pscredential]$SecurePassword
     )
     if(-not $PSboundparameters.SecurePassword){$pass = $null}
-	else{$pass = $SecurePassword.Password}
+    else{$pass = $SecurePassword.Password}
 
     $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
     $certificate.Import($Path, $pass, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet)

--- a/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.schema.mof
+++ b/DSCResources/RS_rsCertificateStore/RS_rsCertificateStore.schema.mof
@@ -1,10 +1,11 @@
 [ClassVersion("1.0"), FriendlyName("rsCertificateStore")]
 class RS_rsCertificateStore : OMI_BaseResource
 {
-[Key] string Name;
-[write] string Path;
-[write,ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
-[write] string Store;
-[write] string Password;
+[Key, Description("Name or Thumbprint of Certificate")] String Name;
+[write, Description("Location of Certificate or PFX file for installation")] String Path;
+[write,ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] String Location;
+[write, Description("Certificate Stores to place certificate in.")] String Store[];
+[write, Description("plaintext password for PFX file.")] String Password;
+[write, Description("Secure password for PFX file."),EmbeddedInstance("MSFT_Credential")] String SecurePassword;
 [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
 };

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ rsSSL
 Originated at: https://github.com/PowerShellOrg/DSC/tree/master/Resources/StackExchangeResources/DSCResources/StackExchange_CertificateStore
 
 Used for SSL installation. PFX password support added by RS.
+Updated for Secure Password (PSCredential)
+Tests added for Thumbprint-based management checks
 ```PoSh
 rsCertificateStore cert_1
 {
@@ -12,5 +14,15 @@ rsCertificateStore cert_1
   Location = "LocalMachine"
   Store = "WebHosting"
   Password = "rack"
+}
+
+rsCertificateStore cert_2
+{
+  Ensure = "Present"
+  Name = "devops_selfsigned.net"
+  Path = "C:\DevOps\DDI_rsConfigs\certificates\rackspacedevops.net.2015.pfx"
+  Location = "LocalMachine"
+  Store = @("My", "Root")
+  SecurePassword = $Credentials."devops_selfsigned.net"
 }
 ```


### PR DESCRIPTION
This update includes the following commit-changes:
SecurePassword: utilize a PSCredential for securely storing password privately in MOF.
Store: Set store to an array of strings element to support more than one store. Important if wanting a single certificate in multiple certificate stores (self-signed as example.)
Thumbprint: Added / updated feature test for thumbprint against the original certificate file, included password protected files, to grab the thumbprint for use in testing if certificate is installed in each store.
Name: Name is key value, and need not match any specific element, however if the original cert is removed from repo and control of present / absent is desired, set Name as thumbprint.